### PR TITLE
ci: move to v4 download-artifact

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
     - name: Download artefact
       if: ${{ inputs.artefactName != null }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artefactName }}
         path: ./_tmpuragha/out


### PR DESCRIPTION
This pull request includes an update to the `action.yml` file to use a newer version of the `download-artifact` action.

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L43-R43): Updated the `actions/download-artifact` action from version 3 to version 4.